### PR TITLE
Add persistent housing & furnishing

### DIFF
--- a/packages/greenbox-data/data/items.ts
+++ b/packages/greenbox-data/data/items.ts
@@ -1,3 +1,58 @@
+// https://wiki.kingdomofloathing.com/Resting
+// Only add items that persist on ascension and won't be destroyed when resting
+// These will be added only if they are installed
+export const housingItems = [
+  // Housing
+  69, // Newbiesport™ tent
+  73, // barskin tent
+  143, // cottage
+  526, // Frobozz Real-Estate Company Instant House (TM)
+  3127, // sandcastle
+  3374, // house of twigs and spit
+  3416, // hobo fortress blueprints
+  4347, // gingerbread house
+  4485, // BRICKO pyramid
+  4771, // ginormous pumpkin
+  6668, // giant Faraday cage
+  7089, // snow fort
+  7295, // elevent
+  7758, // Xiblaxian residence-cube
+  9185, // giant pilgrim hat
+  10497, // house-sized mushroom
+  11600, // mini kiwi tipi
+
+  // Beds
+  429, // beanbag chair
+  2638, // gauze hammock
+  3344, // bed of coals
+  3345, // frigid air mattress
+  3346, // filth-encrusted futon
+  3347, // comfy coffin
+  3348, // stained mattress
+  4842, // sleeping stocking
+  5888, // Lazybones™ recliner
+  6338, // saltwaterbed
+  6890, // spirit bed
+  11345, // forest canopy bed
+
+  // Furnishings
+  133, // Certificate of Participation
+  210, // Feng Shui for Big Dumb Idiots
+  636, // meat globe
+  4344, // Crimbo wreath
+  4345, // string of Crimbo lights
+  4346, // plastic Crimbo reindeer
+  6120, // bonsai tree
+  6122, // lucky cat statue
+  6614, // cuckoo clock
+  6773, // tin roof (rusted)
+  10072, // Crimbo candle
+  11891, // wet blanket
+  12206, // Pork Elf medicine cabinet
+  12207, // Pork Elf sink
+  12208, // Pork Elf toilet
+] as const;
+
 export const specialItems = [
   //// Quest Rewards
   // Marty's Quest

--- a/packages/greenbox-data/lib/items.ts
+++ b/packages/greenbox-data/lib/items.ts
@@ -1,4 +1,4 @@
-import { specialItems } from "../data/items.js";
+import { housingItems, specialItems } from "../data/items.js";
 
 export enum ItemStatus {
   NONE = 0,
@@ -21,4 +21,4 @@ export const expandItems = (s = ""): RawItem[] =>
     return [Number(parts[0]), parts[1] ? Number(parts[1]) : 1];
   });
 
-export { specialItems };
+export { housingItems, specialItems };

--- a/packages/greenbox-script/src/greenbox.ts
+++ b/packages/greenbox-script/src/greenbox.ts
@@ -26,6 +26,7 @@ import {
   TrophyDef,
   TrophyStatus,
   VERSION,
+  housingItems,
 } from "greenbox-data";
 import {
   currentRound,
@@ -44,7 +45,7 @@ import {
   toInt,
   visitUrl,
 } from "kolmafia";
-import { Kmail, property } from "libram";
+import { haveInCampground, Kmail, property } from "libram";
 
 import { getBindableStatus, BindableOptions } from "./bindable.js";
 import { haveItem } from "./utils.js";
@@ -72,12 +73,20 @@ function checkIotYs(options: BindableOptions = {}): RawBindable[] {
  * @returns array of 2-tuples of item id and status
  */
 function checkItems(options: Partial<{ force: number[] }> = {}): RawItem[] {
-  return specialItems.map((id) => [
-    id,
-    options.force?.includes(id) || haveItem(Item.get(id))
-      ? ItemStatus.HAVE
-      : ItemStatus.NONE,
-  ]);
+  return [
+    ...specialItems.map((id): RawItem => [
+      id,
+      options.force?.includes(id) || haveItem(Item.get(id))
+        ? ItemStatus.HAVE
+        : ItemStatus.NONE,
+    ]),
+    ...housingItems.map((id): RawItem => [
+      id,
+      options.force?.includes(id) || haveInCampground(Item.get(id))
+        ? ItemStatus.HAVE
+        : ItemStatus.NONE,
+    ]),
+  ];
 }
 
 /**

--- a/packages/greenbox-web/app/components/OtherItems.tsx
+++ b/packages/greenbox-web/app/components/OtherItems.tsx
@@ -2,6 +2,59 @@ import { Accordion } from "@chakra-ui/react";
 
 import ItemGridSection from "./ItemGridSection.js";
 
+const HOUSING = [
+  69, // Newbiesport™ tent
+  73, // barskin tent
+  143, // cottage
+  526, // Frobozz Real-Estate Company Instant House (TM)
+  3127, // sandcastle
+  3374, // house of twigs and spit
+  3416, // hobo fortress blueprints
+  4347, // gingerbread house
+  4485, // BRICKO pyramid
+  4771, // ginormous pumpkin
+  6668, // giant Faraday cage
+  7089, // snow fort
+  7295, // elevent
+  7758, // Xiblaxian residence-cube
+  9185, // giant pilgrim hat
+  10497, // house-sized mushroom
+  11600, // mini kiwi tipi
+];
+
+const BEDS = [
+  429, // beanbag chair
+  2638, // gauze hammock
+  3344, // bed of coals
+  3345, // frigid air mattress
+  3346, // filth-encrusted futon
+  3347, // comfy coffin
+  3348, // stained mattress
+  4842, // sleeping stocking
+  5888, // Lazybones™ recliner
+  6338, // saltwaterbed
+  6890, // spirit bed
+  11345, // forest canopy bed
+];
+
+const FURNISHINGS = [
+  133, // Certificate of Participation
+  210, // Feng Shui for Big Dumb Idiots
+  636, // meat globe
+  4344, // Crimbo wreath
+  4345, // string of Crimbo lights
+  4346, // plastic Crimbo reindeer
+  6120, // bonsai tree
+  6122, // lucky cat statue
+  6614, // cuckoo clock
+  6773, // tin roof (rusted)
+  10072, // Crimbo candle
+  11891, // wet blanket
+  12206, // Pork Elf medicine cabinet
+  12207, // Pork Elf sink
+  12208, // Pork Elf toilet
+];
+
 const RODORIC = [
   2578, // Staff of the Short Order Cook
   2601, // Staff of the Midnight Snack
@@ -74,6 +127,21 @@ const ANNIVERSARY = [
 export default function OtherItems() {
   return (
     <Accordion.Root multiple>
+      <ItemGridSection
+        title="Housing"
+        icon="itemimages/bigtinyhouse.gif"
+        items={HOUSING}
+      />
+      <ItemGridSection
+        title="Beds"
+        icon="itemimages/pillow.gif"
+        items={BEDS}
+      />
+      <ItemGridSection
+        title="Furnishings"
+        icon="itemimages/blacklight.gif"
+        items={FURNISHINGS}
+      />
       <ItemGridSection
         title="Rodoric, the Staffcrafter"
         icon="itemimages/meatstaff.gif"


### PR DESCRIPTION
There's currently a [mafia bug](https://kolmafia.us/threads/get_campground-missing-string-of-crimbo-lights-plastic-crimbo-reindeer-if-installed.32481/) where string of Crimbo lights & plastic Crimbo reindeer are missing
<img width="957" height="644" alt="image" src="https://github.com/user-attachments/assets/c8f7fe25-fe42-4e7d-bb74-d69b57a31bb4" />
